### PR TITLE
0.1.2: a more complete api

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.appsflyer/cloffeine "0.1.1" 
+(defproject com.appsflyer/cloffeine "0.1.2" 
   :description "A warpper over https://github.com/ben-manes/caffeine"
   :url "https://github.com/AppsFlyer/cloffeine"
   :license {:name "Eclipse Public License"

--- a/src/cloffeine/cache.clj
+++ b/src/cloffeine/cache.clj
@@ -13,13 +13,32 @@
 (defn get [^Cache cache k loading-fn]
   (.get cache k (common/ifn->function loading-fn)))
 
+(defn get-all [^Cache cache ks mapping-fn]
+  (into {} (.getAll cache ks (common/ifn->function mapping-fn))))
+
+(defn get-all-present [^Cache cache ks]
+  (into {} (.getAllPresent cache ks)))
+
 (defn get-if-present [^Cache cache k]
   (.getIfPresent cache k))
 
 (defn invalidate! [^Cache cache k]
   (.invalidate cache k))
 
+(defn invalidate-all! 
+  ([^Cache cache]
+   (.invalidateAll cache))
+  ([^Cache cache ks]
+   (.invalidateAll cache ks)))
+
 (defn put! [^Cache cache k v]
   (.put cache k v))
 
+(defn cleanup [^Cache cache]
+  (.cleanUp cache))
 
+(defn estimated-size [^Cache cache]
+  (.estimatedSize cache))
+
+(defn policy [^Cache cache]
+  (.policy cache))

--- a/src/cloffeine/loading_cache.clj
+++ b/src/cloffeine/loading_cache.clj
@@ -23,6 +23,11 @@
   ([^Cache lcache k loading-fn]
    (cache/get lcache k loading-fn)))
 
+(defn cleanup [^Cache lcache]
+  (cache/cleanup lcache))
+
 (defn refresh [^LoadingCache lcache k]
   (.refresh lcache k))
 
+(defn get-all [^LoadingCache lcache ks]
+  (into {} (.getAll lcache ks)))


### PR DESCRIPTION
Added:
- cache: get-all, get-all-present, invalidate-all, cleanup,
         estimated-size, policy
- common: statsCounterSupplier, expireAfter, executor, softValues,
          ticker, removalListener, weigher, writer
- loading-cache: cleanup, get-all
- testing: better coverage, removed all redundant sleep,
           stabilised flaky refresh tests