### PR TITLE
Clarify docstrings; differentiate sync vs. async loader in async cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### VERSION 0.1.9
+* Clarify docstrings
+* Differentiate the construction of an AsyncLoadingCache that uses a CacheLoader
+vs. an AsyncCacheLoader
+
 #### VERSION 0.1.8
 * Bump caffeine to 2.8.8
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cloffeine 
 
-Simple clojure wrapper around https://github.com/ben-manes/caffeine cache.
+Simple clojure wrapper over [`Caffeine`](https://github.com/ben-manes/caffeine).
 
 [![Clojars Project](https://img.shields.io/clojars/v/com.appsflyer/cloffeine.svg)](https://clojars.org/com.appsflyer/cloffeine)
 
@@ -8,14 +8,16 @@ Simple clojure wrapper around https://github.com/ben-manes/caffeine cache.
 
 [![cljdoc badge](https://cljdoc.org/badge/com.appsflyer/cloffeine)](https://cljdoc.org/d/com.appsflyer/cloffeine/CURRENT)
 
-
-add `[com.appsflyer/cloffeine "0.1.8"]` under `:dependencies`
+## Installing
+Add `[com.appsflyer/cloffeine "0.1.9"]` to your `project.clj` under `:dependencies`.
 
 ## [Checkout the docs](https://appsflyer.github.io/cloffeine/index.html)
 
-Usage:
-------
-Manual loading:
+
+
+## Usage
+
+### Manual loading
 
 ```clojure
 (require '[cloffeine.cache :as cache])
@@ -28,7 +30,7 @@ Manual loading:
 (is (= "key" (cache/get cache :key name)))
 ```
 
-Automatic loading
+### Automatic loading
 
 ```clojure
 (require '[cloffeine.loading-cache :as loading-cache])
@@ -52,10 +54,9 @@ Automatic loading
 (cache/invalidate! lcache :key)
 (is (= "key" (cache/get lcache :key name)))
 (is (= 1 @loads))
-
 ```
 
-Async:
+### Async cache
 
 ```clojure
 (require '[cloffeine.async-cache :as async-cache])
@@ -66,10 +67,9 @@ Async:
 (is (= :v @(async-cache/get acache :key name)))
 (async-cache/invalidate! acache :key)
 (is (= "key" @(async-cache/get acache :key name)))
-
 ```
 
-Async with automatic loading:
+### Async with automatic loading:
 
 ```clojure
 (require '[cloffeine.async-loading-cache :as async-loading-cache])

--- a/project.clj
+++ b/project.clj
@@ -1,31 +1,31 @@
-(defproject com.appsflyer/cloffeine "0.1.8" 
+(defproject com.appsflyer/cloffeine "0.1.9"
   :description "A warpper over https://github.com/ben-manes/caffeine"
   :url "https://github.com/AppsFlyer/cloffeine"
   :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
+            :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[com.github.ben-manes.caffeine/caffeine "2.8.8"]]
   :plugins [[lein-codox "0.10.7"]]
   :codox {:output-path "codox"
-          :source-uri "http://github.com/AppsFlyer/cloffeine/blob/{version}/{filepath}#L{line}"
-          :metadata {:doc/format :markdown}}
+          :source-uri  "http://github.com/AppsFlyer/cloffeine/blob/{version}/{filepath}#L{line}"
+          :metadata    {:doc/format :markdown}}
   :profiles {:uberjar {:aot :all}
-             :dev {:plugins [[jonase/eastwood "0.3.5"]
-                             [lein-cloverage "1.1.1"]
-                             [lein-eftest "0.5.9"]
-                             [lein-kibit "0.1.7"]
-                             [com.jakemccrary/lein-test-refresh "0.24.1"]
-                             [lein-cloverage "1.1.2"]
-                             [lein-ancient "0.6.15"]]
-                   :eftest {:multithread? false
-                            :report eftest.report.junit/report
-                            :report-to-file "target/junit.xml"}
-                   :dependencies [[org.clojure/clojure "1.10.1"]
-                                  [criterium "0.4.6"]
-                                  [cheshire "5.10.0"]
-                                  [com.taoensso/timbre "5.1.0"]
-                                  [clj-kondo "RELEASE"]
-                                  [funcool/promesa "6.0.0"]
-                                  [com.google.guava/guava-testlib "28.1-jre"]] 
-                   :aliases {"clj-kondo" ["run" "-m" "clj-kondo.main"]
-                             "lint"      ["run" "-m" "clj-kondo.main" "--lint" "src" "test"]}
-                   :global-vars {*warn-on-reflection* true}}})
+             :dev     {:plugins      [[jonase/eastwood "0.3.5"]
+                                      [lein-cloverage "1.1.1"]
+                                      [lein-eftest "0.5.9"]
+                                      [lein-kibit "0.1.7"]
+                                      [com.jakemccrary/lein-test-refresh "0.24.1"]
+                                      [lein-cloverage "1.1.2"]
+                                      [lein-ancient "0.6.15"]]
+                       :eftest       {:multithread?   false
+                                      :report         eftest.report.junit/report
+                                      :report-to-file "target/junit.xml"}
+                       :dependencies [[org.clojure/clojure "1.10.1"]
+                                      [criterium "0.4.6"]
+                                      [cheshire "5.10.0"]
+                                      [com.taoensso/timbre "5.1.0"]
+                                      [clj-kondo "RELEASE"]
+                                      [funcool/promesa "6.0.0"]
+                                      [com.google.guava/guava-testlib "28.1-jre"]]
+                       :aliases      {"clj-kondo" ["run" "-m" "clj-kondo.main"]
+                                      "lint"      ["run" "-m" "clj-kondo.main" "--lint" "src" "test"]}
+                       :global-vars  {*warn-on-reflection* true}}})

--- a/src/cloffeine/async_cache.clj
+++ b/src/cloffeine/async_cache.clj
@@ -1,13 +1,15 @@
 (ns cloffeine.async-cache
   (:refer-clojure :exclude [get])
-  (:require [cloffeine.common :as common]
-            [cloffeine.cache :as cache])
+  (:require [cloffeine.cache :as cache]
+            [cloffeine.common :as common])
   (:import [com.github.benmanes.caffeine.cache AsyncCache]))
 
 (defn make-cache
   "Create an AsyncCache. See `cloffeine.common/builder` for settings.
-  A semi-persistent mapping from keys to values. Values are automatically loaded by the cache asynchronously, and are stored in the cache until either evicted or manually invalidated.
-Implementations of this interface are expected to be thread-safe, and can be safely accessed by multiple concurrent threads."
+  A semi-persistent mapping from keys to values. Values should be manually set in
+  the cache using cloffeine.async-cache/put!.
+  Implementations of this interface are expected to be thread-safe, and can be
+  safely accessed by multiple concurrent threads."
   (^AsyncCache []
    (make-cache {}))
   (^AsyncCache [settings]
@@ -15,27 +17,30 @@ Implementations of this interface are expected to be thread-safe, and can be saf
      (.buildAsync bldr))))
 
 (defn get
-  "Returns the future associated with key in this cache, obtaining that value from mappingFunction if necessary."
+  "Returns the future associated with the key in this cache, obtaining that value
+  from mappingFunction if necessary."
   [^AsyncCache acache k f]
   (.get acache k (common/ifn->function f)))
 
-(defn get-if-present "Returns the future associated with key in this cache, or null if there is no cached future for key."
+(defn get-if-present
+  "Returns the future associated with key in this cache, or nil if there is no
+  cached future for key."
   [^AsyncCache acache k]
-    ;; TODO: acache can return nil. always wrap in future?
+  ;; TODO: acache can return nil. always wrap in future?
   (.getIfPresent acache k))
 
-(defn put! 
+(defn put!
   "Associates value with key in this cache."
   [^AsyncCache acache k future-v]
   (.put acache k future-v))
 
 (defn ->Cache
-  "Returns a view of the entries stored in this cache as a synchronous Cache."
+  "Returns a view of the entries stored in this cache as a synchronous cache."
   [^AsyncCache acache]
   (.synchronous acache))
 
 (defn invalidate!
-  "Discards any cached value for the key."
+  "Disassociates the value cached for the key."
   [^AsyncCache acache k]
   (-> acache
       ->Cache

--- a/src/cloffeine/async_cache.clj
+++ b/src/cloffeine/async_cache.clj
@@ -7,9 +7,7 @@
 (defn make-cache
   "Create an AsyncCache. See `cloffeine.common/builder` for settings.
   A semi-persistent mapping from keys to values. Values should be manually set in
-  the cache using cloffeine.async-cache/put!.
-  Implementations of this interface are expected to be thread-safe, and can be
-  safely accessed by multiple concurrent threads."
+  the cache using cloffeine.async-cache/put!."
   (^AsyncCache []
    (make-cache {}))
   (^AsyncCache [settings]

--- a/src/cloffeine/async_loading_cache.clj
+++ b/src/cloffeine/async_loading_cache.clj
@@ -13,9 +13,7 @@
   "Create an AsyncLoadingCache. See `cloffeine.common/builder` for settings.
   A semi-persistent mapping from keys to values. Values are automatically loaded
   by the cache synchronously, and are stored in the cache until either evicted
-  or manually invalidated.
-  Implementations of this interface are expected to be thread-safe, and can be
-  safely accessed by multiple concurrent threads."
+  or manually invalidated."
   (^AsyncLoadingCache [^CacheLoader cache-loader]
    (make-cache cache-loader {}))
   (^AsyncLoadingCache [^CacheLoader cache-loader settings]

--- a/src/cloffeine/async_loading_cache.clj
+++ b/src/cloffeine/async_loading_cache.clj
@@ -1,48 +1,58 @@
 (ns cloffeine.async-loading-cache
   (:refer-clojure :exclude [get])
-  (:require [cloffeine.common :as common]
-            [cloffeine.async-cache :as acache]
+  (:require [cloffeine.async-cache :as acache]
+            [cloffeine.common :as common]
             [cloffeine.loading-cache :as loading-cache])
-  (:import [com.github.benmanes.caffeine.cache 
-            AsyncCache 
-            AsyncLoadingCache 
-            AsyncCacheLoader]))
+  (:import [com.github.benmanes.caffeine.cache
+            AsyncCache
+            AsyncLoadingCache
+            AsyncCacheLoader
+            CacheLoader]))
 
 (defn make-cache
   "Create an AsyncLoadingCache. See `cloffeine.common/builder` for settings.
-   A semi-persistent mapping from keys to values. Values are automatically loaded by the cache asynchronously, and are stored in the cache until either evicted or manually invalidated.)
-Implementations of this interface are expected to be thread-safe, and can be safely accessed by multiple concurrent threads."
-  (^AsyncLoadingCache [cache-loader]
+  A semi-persistent mapping from keys to values. Values are automatically loaded
+  by the cache synchronously, and are stored in the cache until either evicted
+  or manually invalidated.
+  Implementations of this interface are expected to be thread-safe, and can be
+  safely accessed by multiple concurrent threads."
+  (^AsyncLoadingCache [^CacheLoader cache-loader]
    (make-cache cache-loader {}))
-  (^AsyncLoadingCache [cache-loader settings]
+  (^AsyncLoadingCache [^CacheLoader cache-loader settings]
    (let [bldr (common/make-builder settings)]
      (.buildAsync bldr cache-loader))))
 
 (defn make-cache-async-loader
-  "Create a CacheLoader"
+  "Create an AsyncLoadingCache that uses an AsyncCacheLoader to asynchronously
+  load missing entries."
   (^AsyncLoadingCache [^AsyncCacheLoader cl]
-   (make-cache cl {}))
+   (make-cache-async-loader cl {}))
   (^AsyncLoadingCache [^AsyncCacheLoader cl settings]
    (let [bldr (common/make-builder settings)]
      (.buildAsync bldr cl))))
 
 (defn get
-  "Returns the future associated with key in this cache, obtaining that value from AsyncCacheLoader.asyncLoad(K, java.util.concurrent.Executor) if necessary."
+  "Returns the future associated with the key in this cache, obtaining that
+  value from AsyncCacheLoader.asyncLoad(K, java.util.concurrent.Executor) if necessary."
   ([^AsyncLoadingCache alcache k]
    (.get alcache k))
   ([^AsyncCache alcache k f]
    (acache/get alcache k f)))
 
-(def get-if-present acache/get-if-present)
-(def put! acache/put!)
+(def ^{:doc "Returns the future associated with key in this cache, or nil if
+             there is no cached future for key."}
+  get-if-present acache/get-if-present)
 
-(defn ->LoadingCache 
-  "Returns a view of the entries stored in this cache as a synchronous LoadingCache."
+(def ^{:doc "Associates value with key in this cache."}
+  put! acache/put!)
+
+(defn ->LoadingCache
+  "Returns a view of the entries stored in this cache as a synchronous cache."
   [^AsyncLoadingCache alcache]
   (.synchronous alcache))
 
 (defn invalidate!
-  "Discards any cached value for the key."
+  "Disassociates the value cached for the key."
   [^AsyncLoadingCache alcache k]
   (-> alcache
       ->LoadingCache

--- a/src/cloffeine/cache.clj
+++ b/src/cloffeine/cache.clj
@@ -1,13 +1,16 @@
 (ns cloffeine.cache
   (:refer-clojure :exclude [get])
   (:require [cloffeine.common :as common])
-  (:import [com.github.benmanes.caffeine.cache Cache]
-           [java.util.concurrent ConcurrentMap]))
+  (:import [java.util.concurrent ConcurrentMap]
+           [com.github.benmanes.caffeine.cache Cache]))
 
 (defn make-cache
-  "Create an AsyncLoadingCache. See `cloffeine.common/builder` for settings.
-  A semi-persistent mapping from keys to values. Cache entries are manually added using get(Object, Function) or put(Object, Object), and are stored in the cache until either evicted or manually invalidated.
-Implementations of this interface are expected to be thread-safe, and can be safely accessed by multiple concurrent threads."
+  "Create a LoadingCache. See `cloffeine.common/builder` for settings.
+  A semi-persistent mapping from keys to values. Cache entries are manually added
+  using get(Object, Function) or put(Object, Object), and are stored in the cache
+  until either evicted or manually invalidated.
+  Implementations of this interface are expected to be thread-safe, and can be
+  safely accessed by multiple concurrent threads."
   (^Cache []
    (make-cache {}))
   (^Cache [settings]
@@ -15,32 +18,35 @@ Implementations of this interface are expected to be thread-safe, and can be saf
      (.build bldr))))
 
 (defn get
-  "Returns the value associated with the key in this cache, obtaining that value from the mappingFunction if necessary."
+  "Returns the value associated with the key in this cache, obtaining that value
+  from the mappingFunction if necessary."
   [^Cache cache k loading-fn]
   (.get cache k (common/ifn->function loading-fn)))
 
 (defn get-all
-  "Returns a map of the values associated with the keys, creating or retrieving those values if necessary."
+  "Returns a map of the values associated with the keys, creating or retrieving
+  those values if necessary using 'mapping-fn'."
   [^Cache cache ks mapping-fn]
   (into {} (.getAll cache ks (common/ifn->function mapping-fn))))
 
 (defn get-all-present
-  "Returns a map of the values associated with the keys in this cache."
+  "Returns a map of all the values associated with the keys in this cache."
   [^Cache cache ks]
   (into {} (.getAllPresent cache ks)))
 
 (defn get-if-present
-  "Returns the value associated with the key in this cache, or null if there is no cached value for the key."
+  "Returns the value associated with the key in this cache, or nil if there is
+  no cached value for the key."
   [^Cache cache k]
   (.getIfPresent cache k))
 
 (defn invalidate!
-  "Discards any cached value for the key."
+  "Disassociates the value cached for the key."
   [^Cache cache k]
   (.invalidate cache k))
 
-(defn invalidate-all! 
-  "Discards all entries in the cache."
+(defn invalidate-all!
+  "Disassociates all the values in the cache."
   ([^Cache cache]
    (.invalidateAll cache))
   ([^Cache cache ks]
@@ -62,7 +68,8 @@ Implementations of this interface are expected to be thread-safe, and can be saf
   (.estimatedSize cache))
 
 (defn policy
-  "Returns access to inspect and perform low-level operations on this cache based on its runtime characteristics."
+  "Returns access to inspect and perform low-level operations on this cache based
+  on its runtime characteristics."
   [^Cache cache]
   (.policy cache))
 
@@ -75,10 +82,12 @@ Implementations of this interface are expected to be thread-safe, and can be saf
   (.compute m k bi-fn))
 
 (defn compute 
-  "see: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentMap.html#compute-K-java.util.function.BiFunction-
-  Attempts to compute a mapping for the specified key and its current mapped value (or null if there is no current mapping). For example, to either create or append a String msg to a value mapping:
+  "Attempts to compute a mapping for the specified key and its current mapped
+  value (or nil if there is no current mapping).
+  For example, to either create or append a String msg to a value mapping:
   `(compute cache \"k\" (fn [k, v] (if (nil? v) msg (str v msg)))`
- "
+
+  See: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentMap.html#compute-K-java.util.function.BiFunction-"
   [^Cache cache k remapper-fn]
   (let [bi-fn (common/ifn->bifunction remapper-fn)]
     (-> cache

--- a/src/cloffeine/cache.clj
+++ b/src/cloffeine/cache.clj
@@ -8,9 +8,7 @@
   "Create a LoadingCache. See `cloffeine.common/builder` for settings.
   A semi-persistent mapping from keys to values. Cache entries are manually added
   using get(Object, Function) or put(Object, Object), and are stored in the cache
-  until either evicted or manually invalidated.
-  Implementations of this interface are expected to be thread-safe, and can be
-  safely accessed by multiple concurrent threads."
+  until either evicted or manually invalidated."
   (^Cache []
    (make-cache {}))
   (^Cache [settings]

--- a/src/cloffeine/common.clj
+++ b/src/cloffeine/common.clj
@@ -1,12 +1,16 @@
 (ns cloffeine.common
-  (:import [com.github.benmanes.caffeine.cache Caffeine CacheLoader AsyncCacheLoader Cache CacheWriter
-            Weigher]
+  (:import [com.github.benmanes.caffeine.cache AsyncCacheLoader
+                                               Cache
+                                               CacheLoader
+                                               CacheWriter
+                                               Caffeine
+                                               Weigher]
            [com.github.benmanes.caffeine.cache.stats CacheStats]
-           [java.util.function Function BiFunction]
+           [java.util.function BiFunction Function]
            [java.util.concurrent TimeUnit]))
 
 (defn- time-unit
-  [tu] 
+  [tu]
   (case tu
     :ms TimeUnit/MILLISECONDS
     :us TimeUnit/MICROSECONDS
@@ -16,55 +20,82 @@
     :d TimeUnit/DAYS))
 
 (defn make-builder
-  "A builder for the various types of Caffeine's caches (AsyncCache, AsyncLoadingCache, Cache, LoadingCache). The corresponding `create` functions, accept and pass here this config to create the required cache.
+  "A builder for the various types of Caffeine's caches (AsyncCache,
+  AsyncLoadingCache, Cache, LoadingCache). The corresponding `create` functions,
+  accept and pass here this config to create the required cache.
   `settings` is a map with the keys (all optional):
 
   * `:recordStats` `boolean`
-  * `:statsCounterSupplier` a `com.github.benmanes.caffeine.cache.stats.StatsCounter`, mutually exclusive with `:recordStats`
+  * `:statsCounterSupplier` a `com.github.benmanes.caffeine.cache.stats.StatsCounter`,
+      mutually exclusive with `:recordStats`
   * `:maximumSize` `long` Specifies the maximum number of entries the cache may contain.
   * `:expireAfter` `com.github.benmanes.caffeine.cache.Expiry`
-  * `:expireAfterAccess` `long`, references :timeUnit. Specifies that each entry should be automatically removed from the cache once a fixed duration has elapsed after the entry's creation, the most recent replacement of its value, or its last read.
-  * `:expireAfterWrite` `long`, references :timeUnit. Specifies that active entries are eligible for automatic refresh once a fixed duration has elapsed after the entry's creation, or the most recent replacement of its value. 
-  * `:executor` `java.util.concurrent.Executor` Specifies the executor to use when running asynchronous tasks.
-  * `:weakKeys` `boolean`. Specifies that each key (not value) stored in the cache should be wrapped in a WeakReference (by default, strong references are used).
+  * `:expireAfterAccess` `long`, references :timeUnit. Specifies that each entry
+      should be automatically removed from the cache once a fixed duration has
+      elapsed after the entry's creation, the most recent replacement of its value,
+      or its last read.
+  * `:expireAfterWrite` `long`, references :timeUnit. Specifies that active entries
+      are eligible for automatic refresh once a fixed duration has elapsed after
+      the entry's creation, or the most recent replacement of its value.
+  * `:executor` `java.util.concurrent.Executor` Specifies the executor to use when
+      running asynchronous tasks.
+  * `:weakKeys` `boolean`. Specifies that each key (not value) stored in the cache
+      should be wrapped in a WeakReference (by default, strong references are used).
   * `:initialCapacity` 'long'. Sets the minimum total size for the internal data structures.
-  * `:softValues` `Boolean` Specifies that each value (not key) stored in the cache should be wrapped in a SoftReference (by default, strong references are used). Softly-referenced objects will be garbage-collected in a globally least-recently-used manner, in response to memory demand.
-  * `:ticker` `com.github.benmanes.caffeine.cache.Ticker` Specifies a nanosecond-precision time source for use in determining when entries should be expired or refreshed. By default, System.nanoTime() is used.
-  * `:removalListener` `com.github.benmanes.caffeine.cache.RemovalListener` Specifies a listener instance that caches should notify each time an entry is removed for any reason. Each cache created by this builder will invoke this listener as part of the routine maintenance described in the class documentation above.
-  * `:weigher` `com.github.benmanes.caffeine.cache.Weigher` Specifies the weigher to use in determining the weight of entries.
-  * `:writer` `com.github.benmanes.caffeine.cache.CacheWriter` Specifies a writer instance that caches should notify each time an entry is explicitly created or modified, or removed for any reason.
+  * `:softValues` `Boolean` Specifies that each value (not key) stored in the cache
+      should be wrapped in a SoftReference (by default, strong references are used).
+      Softly-referenced objects will be garbage-collected in a globally
+      least-recently-used manner, in response to memory demand.
+  * `:ticker` `com.github.benmanes.caffeine.cache.Ticker` Specifies a
+      nanosecond-precision time source for use in determining when entries should
+      be expired or refreshed. By default, System.nanoTime() is used.
+  * `:removalListener` `com.github.benmanes.caffeine.cache.RemovalListener`.
+      Specifies a listener instance that caches should notify each time an entry
+      is removed for any reason. Each cache created by this builder will invoke
+      this listener as part of the routine maintenance described in the class
+      documentation above.
+  * `:weigher` `com.github.benmanes.caffeine.cache.Weigher` Specifies the weigher
+      to use in determining the weight of entries.
+  * `:writer` `com.github.benmanes.caffeine.cache.CacheWriter` Specifies a writer
+      instance that caches should notify each time an entry is explicitly created
+      or modified, or removed for any reason.
   * `:timeUnit` ``[:ms :us :s :m :h :d]`` default is `:s`"
   ^Caffeine [settings]
-  (let [bldr (Caffeine/newBuilder)
+  (let [bldr     (Caffeine/newBuilder)
         settings (merge {:timeUnit :s} settings)
         timeUnit (time-unit (:timeUnit settings))]
     (when (and (:recordStats settings)
                (:statsCounterSupplier settings))
       (throw (ex-info "Configuration error. :recordStats and :statsCounterSupplier are mutually exclusive" settings)))
     (cond-> bldr
-      (:recordStats settings) (.recordStats)
-      (:statsCounterSupplier settings) (.recordStats (:statsCounterSupplier settings))
-      (:maximumSize settings) (.maximumSize (int (:maximumSize settings)))
-      (:expireAfter settings) (.expireAfter (:expireAfter settings))
-      (:expireAfterAccess settings) (.expireAfterAccess (:expireAfterAccess settings) timeUnit)
-      (:expireAfterWrite settings) (.expireAfterWrite (:expireAfterWrite settings) timeUnit)
-      (:refreshAfterWrite settings) (.refreshAfterWrite (:refreshAfterWrite settings) timeUnit)
-      (:executor settings) (.executor (:executor settings))
-      (:weakKeys settings) (.weakKeys)
-      (:weakValues settings) (.weakValues)
-      (:initialCapacity settings) (.initialCapacity (int (:initialCapacity settings)))
-      (:softValues settings) (.softValues)
-      (:ticker settings) (.ticker (:ticker settings))
-      (:removalListener settings) (.removalListener (:removalListener settings))
-      (:weigher settings) (.weigher (:weigher settings))
-      (:writer settings) (.writer (:writer settings)))))
+            (:recordStats settings) (.recordStats)
+            (:statsCounterSupplier settings) (.recordStats (:statsCounterSupplier settings))
+            (:maximumSize settings) (.maximumSize (int (:maximumSize settings)))
+            (:expireAfter settings) (.expireAfter (:expireAfter settings))
+            (:expireAfterAccess settings) (.expireAfterAccess (:expireAfterAccess settings) timeUnit)
+            (:expireAfterWrite settings) (.expireAfterWrite (:expireAfterWrite settings) timeUnit)
+            (:refreshAfterWrite settings) (.refreshAfterWrite (:refreshAfterWrite settings) timeUnit)
+            (:executor settings) (.executor (:executor settings))
+            (:weakKeys settings) (.weakKeys)
+            (:weakValues settings) (.weakValues)
+            (:initialCapacity settings) (.initialCapacity (int (:initialCapacity settings)))
+            (:softValues settings) (.softValues)
+            (:ticker settings) (.ticker (:ticker settings))
+            (:removalListener settings) (.removalListener (:removalListener settings))
+            (:weigher settings) (.weigher (:weigher settings))
+            (:writer settings) (.writer (:writer settings)))))
 
 (defn reify-async-cache-loader
- "A helper for implemeting an `AsyncCacheLoader`.
- 
- * `loading-fn` ``(fn [this k executor])``. Asynchronously computes or retrieves the value corresponding to key.
- * `reloading-fn` (optional) ``(fn [this k old-val executor])`` Asynchronously computes or retrieves a replacement value corresponding to an already-cached key. If the replacement value is not found then the mapping will be removed if null is computed. This method is called when an existing cache entry is refreshed by Caffeine.refreshAfterWrite(java.time.Duration), or through a call to LoadingCache.refresh(K).
- "
+  "A helper for implementing an `AsyncCacheLoader`.
+
+  * `loading-fn` - `(fn [this k executor])`. Asynchronously computes or retrieves
+      the value corresponding to key.
+  * `reloading-fn` (optional) ``(fn [this k old-val executor])`` Asynchronously
+      computes or retrieves a replacement value corresponding to an already-cached
+      key. If the replacement value is not found then the mapping will be removed
+      if nil is computed. This method is called when an existing cache entry is
+      refreshed by Caffeine.refreshAfterWrite(java.time.Duration),
+      or through a call to LoadingCache.refresh(K). "
   ([loading-fn]
    (reify AsyncCacheLoader
      (asyncLoad [_this k executor]
@@ -76,11 +107,13 @@
      (asyncReload [_this k v executor]
        (reloading-fn k v executor)))))
 
-(defn reify-cache-loader 
-  "A helper for implemeting `CacheLoader`
+(defn reify-cache-loader
+  "A helper for implementing `CacheLoader`.
   
-  * `loading-fn `(fn [this k])` Computes or retrieves the value corresponding to key.
-  * `relaoding-fn` `(fn [this k old-val]) Computes or retrieves a replacement value corresponding to an already-cached key."
+  * `loading-fn` - `(fn [this k])`. Computes or retrieves the value corresponding
+      to key.
+  * `relaoding-fn` - `(fn [this k old-val])`. Computes or retrieves a replacement
+      value corresponding to an already-cached key."
   ([loading-fn]
    (reify CacheLoader
      (load [_this k]
@@ -93,10 +126,12 @@
        (reloading-fn k v)))))
 
 (defn reify-cache-writer
-  "A helper for implementing` CacheWriter`
+  "A helper for implementing `CacheWriter`
   
-  * `delete-handler` `(fn [this k v removal-cause])` Deletes the value corresponding to the key from the external resource.
-  * `write-handler` `(fn [this k v])` Writes the value corresponding to the key to the external resource."
+  * `delete-handler` - `(fn [this k v removal-cause])`. Deletes the value
+    corresponding to the key from the external resource.
+  * `write-handler` - `(fn [this k v])`. Writes the value corresponding to the
+    key to the external resource."
   [delete-handler write-handler]
   (reify CacheWriter
     (delete ^void [this k v removal-cause]
@@ -104,11 +139,11 @@
     (write ^void [this k v]
       (write-handler this k v))))
 
-(defn reify-weigher 
-  "A helper for implemeting `Weigher`
+(defn reify-weigher
+  "A helper for implementing `Weigher`.
   
-  `weigh-fn` `(fn [this k v])` Returns the weight of a cache entry (int). There is no unit for entry weights; rather they are simply relative to each other.
-"
+  * `weigh-fn` - `(fn [this k v])`. Returns the weight of a cache entry (int).
+  There is no unit for entry weights; rather they are simply relative to each other."
   [weigh-fn]
   (reify Weigher
     (weigh ^Int [this k v]
@@ -124,25 +159,27 @@
     (apply [_this t u]
       (ifn t u))))
 
-(defn cache-stats->map 
-  "Convert CacheStats object readonly attributes to a clojure map
-  see: https://www.javadoc.io/static/com.github.ben-manes.caffeine/caffeine/2.8.0/com/github/benmanes/caffeine/cache/stats/CacheStats.html
+(defn cache-stats->map
+  "Convert a CacheStats object readonly attributes to a Clojure map.
+
+  See: https://www.javadoc.io/static/com.github.ben-manes.caffeine/caffeine/2.8.0/com/github/benmanes/caffeine/cache/stats/CacheStats.html
   for actual metrics docs."
   [^CacheStats cs]
   {:averageLoadPenalty (.averageLoadPenalty cs)
-   :evictionCount (.evictionCount cs)
-   :evictionWeight (.evictionWeight cs)
-   :hitCount (.hitCount cs)
-   :hitRate (.hitRate cs)
-   :loadCount (.loadCount cs)
-   :loadFailureCount (.loadFailureCount cs)
-   :loadFailureRate (.loadFailureRate cs)
-   :loadSuccessCount (.loadSuccessCount cs)
-   :missCount (.missCount cs)
-   :missRate (.missRate cs)
-   :requestCount (.requestCount cs)
-   :totalLoadTime (.totalLoadTime cs)})
-   
-(defn stats "Returns a current snapshot of this cache's cumulative statistics."
+   :evictionCount      (.evictionCount cs)
+   :evictionWeight     (.evictionWeight cs)
+   :hitCount           (.hitCount cs)
+   :hitRate            (.hitRate cs)
+   :loadCount          (.loadCount cs)
+   :loadFailureCount   (.loadFailureCount cs)
+   :loadFailureRate    (.loadFailureRate cs)
+   :loadSuccessCount   (.loadSuccessCount cs)
+   :missCount          (.missCount cs)
+   :missRate           (.missRate cs)
+   :requestCount       (.requestCount cs)
+   :totalLoadTime      (.totalLoadTime cs)})
+
+(defn stats
+  "Returns a current snapshot of this cache's cumulative statistics."
   [^Cache c]
   (cache-stats->map (.stats c)))

--- a/src/cloffeine/loading_cache.clj
+++ b/src/cloffeine/loading_cache.clj
@@ -1,27 +1,35 @@
 (ns cloffeine.loading-cache
   (:refer-clojure :exclude [get])
-  (:require [cloffeine.common :as common]
-            [cloffeine.cache :as cache])
-  (:import [com.github.benmanes.caffeine.cache Cache LoadingCache CacheLoader]))
+  (:require [cloffeine.cache :as cache]
+            [cloffeine.common :as common])
+  (:import [com.github.benmanes.caffeine.cache Cache CacheLoader LoadingCache]))
 
 (defn make-cache
-  "Create an AsyncLoadingCache. See `cloffeine.common/builder` for settings.
-  A semi-persistent mapping from keys to values. Values are automatically loaded by the cache, and are stored in the cache until either evicted or manually invalidated.
-Implementations of this interface are expected to be thread-safe, and can be safely accessed by multiple concurrent threads."
+  "Create a LoadingCache. See `cloffeine.common/builder` for settings.
+  A semi-persistent mapping from keys to values. Values are automatically loaded
+  by the cache, and are stored in the cache until either evicted or manually
+  invalidated.
+  Implementations of this interface are expected to be thread-safe, and can be
+  safely accessed by multiple concurrent threads."
   (^LoadingCache [^CacheLoader cl]
    (make-cache cl {}))
   (^LoadingCache [^CacheLoader cl settings]
    (let [bldr (common/make-builder settings)]
      (.build bldr cl))))
 
-(def get-if-present cache/get-if-present)
+(def ^{:doc "Returns the value associated with the key in this cache, or nil if
+            there is no cached value for the key."}
+  get-if-present cache/get-if-present)
 
-(def invalidate! cache/invalidate!)
+(def ^{:doc "Disassociates the value cached for the key."}
+  invalidate! cache/invalidate!)
 
-(def put! cache/put!)
+(def ^{:doc "Associates the value with the key in this cache."}
+  put! cache/put!)
 
 (defn get
-  "Returns the value associated with the key in this cache, obtaining that value from CacheLoader.load(Object) if necessary."
+  "Returns the value associated with the key in this cache, obtaining that value
+  from CacheLoader.load(Object) if necessary."
   ([^LoadingCache lcache k]
    (.get lcache k))
   ([^Cache lcache k loading-fn]
@@ -38,6 +46,7 @@ Implementations of this interface are expected to be thread-safe, and can be saf
   (.refresh lcache k))
 
 (defn get-all 
-  "Returns a map of the values associated with the keys, creating or retrieving those values if necessary."
+  "Returns a map of the values associated with the keys, creating or retrieving
+  those values if necessary."
   [^LoadingCache lcache ks]
   (into {} (.getAll lcache ks)))

--- a/src/cloffeine/loading_cache.clj
+++ b/src/cloffeine/loading_cache.clj
@@ -8,9 +8,7 @@
   "Create a LoadingCache. See `cloffeine.common/builder` for settings.
   A semi-persistent mapping from keys to values. Values are automatically loaded
   by the cache, and are stored in the cache until either evicted or manually
-  invalidated.
-  Implementations of this interface are expected to be thread-safe, and can be
-  safely accessed by multiple concurrent threads."
+  invalidated."
   (^LoadingCache [^CacheLoader cl]
    (make-cache cl {}))
   (^LoadingCache [^CacheLoader cl settings]

--- a/test/cloffeine/core_test.clj
+++ b/test/cloffeine/core_test.clj
@@ -10,7 +10,8 @@
   (:import [com.google.common.testing FakeTicker]
            [com.github.benmanes.caffeine.cache Ticker]
            [java.util.concurrent TimeUnit]
-           [java.util.logging Logger Level]))
+           [java.util.logging Logger Level]
+           [clojure.lang ExceptionInfo]))
 
 (defn configure-logger [test-fn]
   (let [logger (Logger/getLogger "com.github.benmanes.caffeine")
@@ -94,7 +95,7 @@
       (is (= 1 @loads)))
     (testing "fail to load a missing key throws exception"
       (reset! throw? true)
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"fail"
+      (is (thrown-with-msg? ExceptionInfo #"fail"
                             (loading-cache/get lcache :missing-key)))
       (is (= 1 @loads)))
     (testing "fail to load an expired key"


### PR DESCRIPTION
The main change in this PR is differentiating between a `CacheLoader` and an `AsyncCacheLoader` in an `AsyncCache` - how values are obtained by the loader has no bearing on the fact that the cache itself will return a `CompletableFuture`, which could already be resolved as the requested key is already present in the cache (see `make-cache-async-loader`).

All the changes to docstrings are just general clean-up.