### PR TITLE
caffeine 2.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ fabric.properties
 .classpath
 .project
 .settings
+.lsp

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject com.appsflyer/cloffeine "0.1.9"
+(defproject com.appsflyer/cloffeine "0.2.0"
   :description "A warpper over https://github.com/ben-manes/caffeine"
   :url "https://github.com/AppsFlyer/cloffeine"
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[com.github.ben-manes.caffeine/caffeine "2.8.8"]]
+  :dependencies [[com.github.ben-manes.caffeine/caffeine "2.9.0"]]
   :plugins [[lein-codox "0.10.7"]]
   :codox {:output-path "codox"
           :source-uri  "http://github.com/AppsFlyer/cloffeine/blob/{version}/{filepath}#L{line}"


### PR DESCRIPTION
see upstream release in
[2.9.0](https://github.com/ben-manes/caffeine/releases/tag/v2.9.0)
removed support of `:removalListener` and support only the
more general `:evictionListener`.